### PR TITLE
Replace Adorable Avatar API

### DIFF
--- a/addon/components/adorable/index.js
+++ b/addon/components/adorable/index.js
@@ -19,7 +19,7 @@ class AdorableAvatarComponent extends ImageAvatarComponent {
   }
 
   _adorableSrc(email, size) {
-    return `https://api.adorable.io/avatars/${size}/${email}`;
+    return `https://api.hello-avatar.com/adorables/${size}/${email}`;
   }
 }
 


### PR DESCRIPTION
Recently, the maintainers of Adorable Avatar API choose to shut down their service for economical reasons. Luckily someone offers to use its hosted version of the generator to replace the one shut down. 

See https://github.com/adorableio/avatars-api-middleware/issues/108